### PR TITLE
Prevents event listener from duplicating

### DIFF
--- a/src/handhold.js
+++ b/src/handhold.js
@@ -10,7 +10,7 @@ export default class Handhold {
     this._startBtn = document.querySelector('[data-start-handhold]');
     this._stepElements;
     this._steps;
-    this._resizeObserver;
+    this._listeners;
     this._root;
   }
 
@@ -370,13 +370,13 @@ export default class Handhold {
       (step) => parseInt(step.number) == this._currentStep
     ).element;
     this.removeElements();
+    this.clearListeners();
     this._root.classList.remove('handhold');
-    this._resizeObserver.unobserve(this._root);
-
     return;
   }
 
   keyPressEvents(event) {
+    console.log('testing...')
     if (event && event.keyCode) {
       const key = event.keyCode;
       switch (key) {
@@ -403,28 +403,30 @@ export default class Handhold {
           break;
       }
     }
+
+    return;
   }
 
   setListeners() {
     if (this._active) {
-      this._root.addEventListener('keydown', (event) =>
-        this.keyPressEvents(event)
-      );
+      this._listeners = {
+        keyboard: this._root.addEventListener('keydown', this.keyPressEvents),
+        resize: new ResizeObserver((entries) => {
+          for (const entry of entries) {
+            this.updateElements();
+          }
+        }),
+      };
 
-      // window.addEventListener('scroll', (event) => {
-      //   this.updateElements();
-      // });
-
-      this._resizeObserver = new ResizeObserver((entries) => {
-        for (const entry of entries) {
-          this.updateElements();
-        }
-      });
-
-      this._resizeObserver.observe(this._root);
+      this._listeners.resize.observe(this._root);
     }
 
     return;
+  }
+
+  clearListeners() {
+    this._listeners.resize.unobserve(this._root);
+    this._root.removeEventListener('keydown', this.keyPressEvents);
   }
 
   init() {

--- a/src/handhold.js
+++ b/src/handhold.js
@@ -376,7 +376,6 @@ export default class Handhold {
   }
 
   keyPressEvents(event) {
-    console.log('testing...')
     if (event && event.keyCode) {
       const key = event.keyCode;
       switch (key) {
@@ -409,8 +408,11 @@ export default class Handhold {
 
   setListeners() {
     if (this._active) {
+      const root = this;
       this._listeners = {
-        keyboard: this._root.addEventListener('keydown', this.keyPressEvents),
+        keyboard: function () {
+          root.keyPressEvents(event);
+        },
         resize: new ResizeObserver((entries) => {
           for (const entry of entries) {
             this.updateElements();
@@ -418,6 +420,7 @@ export default class Handhold {
         }),
       };
 
+      this._root.addEventListener('keydown', this._listeners.keyboard);
       this._listeners.resize.observe(this._root);
     }
 
@@ -426,7 +429,7 @@ export default class Handhold {
 
   clearListeners() {
     this._listeners.resize.unobserve(this._root);
-    this._root.removeEventListener('keydown', this.keyPressEvents);
+    this._root.removeEventListener('keydown', this._listeners.keyboard);
   }
 
   init() {

--- a/src/sass/_modal.scss
+++ b/src/sass/_modal.scss
@@ -33,7 +33,9 @@ $modal-radius-var: "var(--modal-radius, #{$modal-radius})";
         var(--hh-transition-function);
       animation: var(--hh-enter-animation);
     }
-
+    &::backdrop{
+      background: transparent;
+    }
     &-title {
       margin: 0;
     }


### PR DESCRIPTION
Issue:
#6 

Updates:
- Fixes issues where `keydown` event listener was being duplicated
- Creates a `clearListeners()` method to clear event listener and resize observer

Screenshot:

https://github.com/ritterim/handholdJS/assets/5217768/f4d5ba2e-aaca-4454-b49b-173abfc36326