### PR TITLE
Use top instead of offsetTop

### DIFF
--- a/src/handhold.mjs
+++ b/src/handhold.mjs
@@ -130,11 +130,10 @@ export default class Handhold {
     const boundingBox = document.querySelector('.handhold-bounding-box');
     boundingBox.innerHTML = '';
     const dimensions = this.getElementDimension(this._currentStepElement);
-    const currentStepPos = this._currentStepElement.offsetTop;
     boundingBox.style = [
       `--hh-boundingbox-height: ${dimensions.height}px`,
       `--hh-boundingbox-width: ${dimensions.width}px`,
-      `--hh-boundingbox-top: ${currentStepPos}px`,
+      `--hh-boundingbox-top: ${dimensions.top}px`,
       `--hh-boundingbox-left: ${dimensions.left}px`,
     ].join(';');
 


### PR DESCRIPTION
https://github.com/ritterim/platform/issues/10556

Using top instead of offsetTop because offsetTop goes off of the parent container element so the bounding box is not rendering in the correct location.