### PR TITLE
Use top instead of offsetTop for modal as well

### DIFF
--- a/src/handhold.mjs
+++ b/src/handhold.mjs
@@ -196,7 +196,7 @@ export default class Handhold {
     const modal = document.querySelector('.handhold-modal');
     const modalTitle = modal.querySelector('.handhold-modal-title');
     const modalContent = modal.querySelector('.handhold-modal-content');
-    const currentStepPos = this._currentStepElement.offsetTop;
+    const currentStepPos = this.getElementDimension(this._currentStepElement).top;
 
     if (this._currentStepElement) {
       const dimensions = this.getElementDimension(step.element);


### PR DESCRIPTION
https://github.com/ritterim/platform/issues/10556

Using top instead of offsetTop because offsetTop goes off of the parent container element so the modal is not rendering in the correct location.